### PR TITLE
Add business rules management and admin dashboard

### DIFF
--- a/dotnet/Capstone/Controllers/BusinessRuleController.cs
+++ b/dotnet/Capstone/Controllers/BusinessRuleController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Mvc;
+using Capstone.DAO.Interfaces;
+using Capstone.Models;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Capstone.Controllers
+{
+    [Route("[controller]")]
+    [ApiController]
+    [Authorize(Roles = "admin")]
+    public class BusinessRuleController : ControllerBase
+    {
+        private readonly IBusinessRuleDao businessRuleDao;
+
+        public BusinessRuleController(IBusinessRuleDao businessRuleDao)
+        {
+            this.businessRuleDao = businessRuleDao;
+        }
+
+        [HttpGet]
+        public ActionResult<IList<BusinessRule>> GetAll()
+        {
+            return Ok(businessRuleDao.GetAllRules());
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<BusinessRule> Get(int id)
+        {
+            BusinessRule rule = businessRuleDao.GetRuleById(id);
+            if (rule == null)
+            {
+                return NotFound();
+            }
+            return Ok(rule);
+        }
+
+        [HttpPost]
+        public ActionResult<BusinessRule> Create(BusinessRule rule)
+        {
+            BusinessRule added = businessRuleDao.AddRule(rule);
+            return Created($"businessrule/{added.Id}", added);
+        }
+
+        [HttpPut("{id}")]
+        public ActionResult<BusinessRule> Update(int id, BusinessRule rule)
+        {
+            if (businessRuleDao.GetRuleById(id) == null)
+            {
+                return NotFound();
+            }
+            rule.Id = id;
+            return Ok(businessRuleDao.UpdateRule(rule));
+        }
+
+        [HttpDelete("{id}")]
+        public ActionResult Delete(int id)
+        {
+            if (!businessRuleDao.DeleteRule(id))
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+    }
+}

--- a/dotnet/Capstone/DAO/BusinessRuleSqlDao.cs
+++ b/dotnet/Capstone/DAO/BusinessRuleSqlDao.cs
@@ -1,0 +1,140 @@
+using Capstone.DAO.Interfaces;
+using Capstone.Models;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System;
+
+namespace Capstone.DAO
+{
+    public class BusinessRuleSqlDao : IBusinessRuleDao
+    {
+        private readonly string connectionString;
+
+        public BusinessRuleSqlDao(string connectionString)
+        {
+            this.connectionString = connectionString;
+        }
+
+        public IList<BusinessRule> GetAllRules()
+        {
+            IList<BusinessRule> rules = new List<BusinessRule>();
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(connectionString))
+                {
+                    conn.Open();
+                    SqlCommand cmd = new SqlCommand("SELECT rule_id, rule_name, description, is_active FROM business_rules", conn);
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        rules.Add(MapRowToBusinessRule(reader));
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error getting business rules");
+            }
+            return rules;
+        }
+
+        public BusinessRule GetRuleById(int id)
+        {
+            BusinessRule rule = null;
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(connectionString))
+                {
+                    conn.Open();
+                    SqlCommand cmd = new SqlCommand("SELECT rule_id, rule_name, description, is_active FROM business_rules WHERE rule_id = @id", conn);
+                    cmd.Parameters.AddWithValue("@id", id);
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        rule = MapRowToBusinessRule(reader);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error getting business rule by id");
+            }
+            return rule;
+        }
+
+        public BusinessRule AddRule(BusinessRule rule)
+        {
+            int newId = 0;
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(connectionString))
+                {
+                    conn.Open();
+                    SqlCommand cmd = new SqlCommand("INSERT INTO business_rules (rule_name, description, is_active) OUTPUT INSERTED.rule_id VALUES (@name, @desc, @active)", conn);
+                    cmd.Parameters.AddWithValue("@name", rule.Name);
+                    cmd.Parameters.AddWithValue("@desc", rule.Description);
+                    cmd.Parameters.AddWithValue("@active", rule.IsActive);
+                    newId = Convert.ToInt32(cmd.ExecuteScalar());
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error adding business rule");
+            }
+            return GetRuleById(newId);
+        }
+
+        public BusinessRule UpdateRule(BusinessRule rule)
+        {
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(connectionString))
+                {
+                    conn.Open();
+                    SqlCommand cmd = new SqlCommand("UPDATE business_rules SET rule_name=@name, description=@desc, is_active=@active WHERE rule_id=@id", conn);
+                    cmd.Parameters.AddWithValue("@id", rule.Id);
+                    cmd.Parameters.AddWithValue("@name", rule.Name);
+                    cmd.Parameters.AddWithValue("@desc", rule.Description);
+                    cmd.Parameters.AddWithValue("@active", rule.IsActive);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error updating business rule");
+            }
+            return GetRuleById(rule.Id);
+        }
+
+        public bool DeleteRule(int id)
+        {
+            int rows = 0;
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(connectionString))
+                {
+                    conn.Open();
+                    SqlCommand cmd = new SqlCommand("DELETE FROM business_rules WHERE rule_id = @id", conn);
+                    cmd.Parameters.AddWithValue("@id", id);
+                    rows = cmd.ExecuteNonQuery();
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error deleting business rule");
+            }
+            return rows > 0;
+        }
+
+        private BusinessRule MapRowToBusinessRule(SqlDataReader reader)
+        {
+            return new BusinessRule
+            {
+                Id = Convert.ToInt32(reader["rule_id"]),
+                Name = Convert.ToString(reader["rule_name"]),
+                Description = Convert.ToString(reader["description"]),
+                IsActive = Convert.ToBoolean(reader["is_active"])
+            };
+        }
+    }
+}

--- a/dotnet/Capstone/DAO/Interfaces/IBusinessRuleDao.cs
+++ b/dotnet/Capstone/DAO/Interfaces/IBusinessRuleDao.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Capstone.Models;
+
+namespace Capstone.DAO.Interfaces
+{
+    public interface IBusinessRuleDao
+    {
+        IList<BusinessRule> GetAllRules();
+        BusinessRule GetRuleById(int id);
+        BusinessRule AddRule(BusinessRule rule);
+        BusinessRule UpdateRule(BusinessRule rule);
+        bool DeleteRule(int id);
+    }
+}

--- a/dotnet/Capstone/Models/BusinessRule.cs
+++ b/dotnet/Capstone/Models/BusinessRule.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Capstone.Models
+{
+    public class BusinessRule
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool IsActive { get; set; }
+    }
+}

--- a/dotnet/Capstone/Startup.cs
+++ b/dotnet/Capstone/Startup.cs
@@ -76,6 +76,7 @@ namespace Capstone
             services.AddTransient<YelpFusionApiService>(m => new YelpFusionApiService(connectionString));
             services.AddTransient<GmailClient>(m => new GmailClient());
             services.AddTransient<IReviewDao>(m => new ReviewSqlDao(connectionString));
+            services.AddTransient<IBusinessRuleDao>(m => new BusinessRuleSqlDao(connectionString));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dotnet/database/capstone.sql
+++ b/dotnet/database/capstone.sql
@@ -48,6 +48,7 @@ DROP TABLE IF EXISTS restaurant_review;
 DROP TABLE IF EXISTS drinks;
 DROP TABLE IF EXISTS restaurants;
 DROP TABLE IF EXISTS reviews;
+DROP TABLE IF EXISTS business_rules;
 
 
 CREATE TABLE drinks (
@@ -110,6 +111,14 @@ restaurant_id INT NOT NULL,
 PRIMARY KEY (drink_id, restaurant_id),
 FOREIGN KEY (drink_id) REFERENCES drinks(drink_id),
 FOREIGN KEY (restaurant_id) REFERENCES restaurants(restaurant_id)
+);
+
+CREATE TABLE business_rules (
+    rule_id int IDENTITY(1,1) NOT NULL,
+    rule_name varchar(100) NOT NULL,
+    description text,
+    is_active bit NOT NULL DEFAULT 1,
+    PRIMARY KEY (rule_id)
 );
 COMMIT;
 GO

--- a/vue/src/components/NavigationBar.vue
+++ b/vue/src/components/NavigationBar.vue
@@ -46,6 +46,12 @@
         >
           Socials
         </button>
+        <button
+          v-if="this.$store.state.user.role === 'admin'"
+          @click="$router.push('/admin')"
+        >
+          Admin
+        </button>
       </div>
     </div>
 </template>

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -12,6 +12,9 @@ import Invite from '../components/InviteUserForm.vue'
 import updateDrinkForm from'../views/UpdateDrinkForm.vue'
 import ReviewList from '../components/ReviewList.vue'
 import SearchDrinksInput from '../components/SearchDrinksInput.vue'
+import AdminDashboard from '../views/AdminDashboard.vue'
+import AddRule from '../views/AddRule.vue'
+import EditRule from '../views/EditRule.vue'
 Vue.use(Router)
 
 /**
@@ -95,6 +98,21 @@ const router = new Router({
             path: "/searchDrinks",
             name: "search-drinks",
             component: SearchDrinksInput
+        },
+        {
+            path: "/admin",
+            name: "admin-dashboard",
+            component: AdminDashboard
+        },
+        {
+            path: "/admin/rules/new",
+            name: "add-rule",
+            component: AddRule
+        },
+        {
+            path: "/admin/rules/:id",
+            name: "edit-rule",
+            component: EditRule
         }
     ]
 })

--- a/vue/src/services/BusinessRuleService.js
+++ b/vue/src/services/BusinessRuleService.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const http = axios.create({
+    baseURL: "https://localhost:44315/"
+});
+
+export default {
+    getRules() {
+        return http.get('businessrule');
+    },
+    getRule(id) {
+        return http.get(`businessrule/${id}`);
+    },
+    addRule(rule) {
+        return http.post('businessrule', rule);
+    },
+    updateRule(id, rule) {
+        return http.put(`businessrule/${id}`, rule);
+    },
+    deleteRule(id) {
+        return http.delete(`businessrule/${id}`);
+    }
+};

--- a/vue/src/views/AddRule.vue
+++ b/vue/src/views/AddRule.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="main">
+    <navigation-bar />
+    <div class="container mt-4">
+      <h2>New Business Rule</h2>
+      <form @submit.prevent="save">
+        <div class="form-group">
+          <label>Name</label>
+          <input v-model="rule.name" class="form-control" required>
+        </div>
+        <div class="form-group">
+          <label>Description</label>
+          <textarea v-model="rule.description" class="form-control"></textarea>
+        </div>
+        <div class="form-check">
+          <input type="checkbox" class="form-check-input" v-model="rule.isActive" id="active">
+          <label class="form-check-label" for="active">Active</label>
+        </div>
+        <button type="submit" class="btn btn-primary mt-2">Save</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import navigationBar from '../components/NavigationBar.vue';
+import ruleService from '../services/BusinessRuleService.js';
+
+export default {
+  components: { navigationBar },
+  data() {
+    return {
+      rule: { name: '', description: '', isActive: true }
+    };
+  },
+  methods: {
+    save() {
+      ruleService.addRule(this.rule).then(() => {
+        this.$router.push('/admin');
+      });
+    }
+  }
+};
+</script>

--- a/vue/src/views/AdminDashboard.vue
+++ b/vue/src/views/AdminDashboard.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="main">
+    <navigation-bar />
+    <div class="container mt-4">
+      <h2>Administrator Dashboard</h2>
+      <p>Total Business Rules: {{ rules.length }}</p>
+      <ul>
+        <li v-for="rule in rules" :key="rule.id">
+          {{ rule.name }} - <router-link :to="{ name: 'edit-rule', params: { id: rule.id } }">Edit</router-link>
+        </li>
+      </ul>
+      <button @click="createNew" class="btn btn-primary">Add Rule</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import navigationBar from '../components/NavigationBar.vue';
+import ruleService from '../services/BusinessRuleService.js';
+
+export default {
+  components: { navigationBar },
+  data() {
+    return {
+      rules: []
+    };
+  },
+  created() {
+    ruleService.getRules().then(r => {
+      this.rules = r.data;
+    });
+  },
+  methods: {
+    createNew() {
+      this.$router.push({ name: 'add-rule' });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.container {
+  max-width: 600px;
+}
+</style>

--- a/vue/src/views/EditRule.vue
+++ b/vue/src/views/EditRule.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="main">
+    <navigation-bar />
+    <div class="container mt-4" v-if="loaded">
+      <h2>Edit Business Rule</h2>
+      <form @submit.prevent="save">
+        <div class="form-group">
+          <label>Name</label>
+          <input v-model="rule.name" class="form-control" required>
+        </div>
+        <div class="form-group">
+          <label>Description</label>
+          <textarea v-model="rule.description" class="form-control"></textarea>
+        </div>
+        <div class="form-check">
+          <input type="checkbox" class="form-check-input" v-model="rule.isActive" id="activeEdit">
+          <label class="form-check-label" for="activeEdit">Active</label>
+        </div>
+        <button type="submit" class="btn btn-primary mt-2">Save</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import navigationBar from '../components/NavigationBar.vue';
+import ruleService from '../services/BusinessRuleService.js';
+
+export default {
+  components: { navigationBar },
+  data() {
+    return {
+      rule: {},
+      loaded: false
+    };
+  },
+  created() {
+    ruleService.getRule(this.$route.params.id).then(r => {
+      this.rule = r.data;
+      this.loaded = true;
+    });
+  },
+  methods: {
+    save() {
+      ruleService.updateRule(this.$route.params.id, this.rule).then(() => {
+        this.$router.push('/admin');
+      });
+    }
+  }
+};
+</script>


### PR DESCRIPTION
## Summary
- add `BusinessRule` entity and DAO for CRUD operations
- wire new DAO into Startup
- create controller secured for admin role
- extend database script with business_rules table
- add Vue services and pages for admin dashboard and rule management
- update navigation to show Admin link when logged in as admin
- register new routes for dashboard and rule forms

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439434fae8833397e8e90eced55423