### PR TITLE
Fix Yelp search base URL

### DIFF
--- a/vue/src/components/AddRestaurantForm.vue
+++ b/vue/src/components/AddRestaurantForm.vue
@@ -119,10 +119,14 @@ export default {
           this.yelpReturn = response.data;
           this.haveYelpData = true;
           this.showAddRestaurantForm = false;
-          this.ShowMainButton = false;
+          this.showMainButton = false;
         })
         .catch((error) => {
-          console.log(error);
+          if (error.response && error.response.status === 404) {
+            alert("Sorry, no results found.");
+          } else {
+            console.log(error);
+          }
         });
     },
     MainButtonClick(){

--- a/vue/src/components/NavigationBar.vue
+++ b/vue/src/components/NavigationBar.vue
@@ -67,16 +67,13 @@ export default {
     components: {
     FontAwesomeIcon,
   },
-  computed() {
-    this.isAuthenticated = this.$store.state.token !== "";
+  computed: {
+    isAuthenticated() {
+      return this.$store.state.token !== "";
+    }
   },
   data() {
-    return {
-      isAuthenticated: false, // Set to false by default
-    };
-  },
-  created() {
-    this.isAuthenticated = this.$store.state.token !== "";
+    return {};
   },
   methods: {
     //this method is part of the scrollToTopfunctaionality at the top nav bar in template, it does not work, but maybe with some cool js and template powers, you can make it work

--- a/vue/src/components/WeatherOutput.vue
+++ b/vue/src/components/WeatherOutput.vue
@@ -26,7 +26,7 @@
             </div>
             <span id="highlightedWeather">
                 <div id="currentWeather" >
-                    <weather-widget v-bind:period="periods[filter]"/>
+                    <weather-widget v-if="periods.length" v-bind:period="periods[filter]"/>
                 </div>
             </span>
       

--- a/vue/src/services/YelpService.js
+++ b/vue/src/services/YelpService.js
@@ -1,15 +1,13 @@
 import axios from 'axios';
 
-// const apiKey = process.env.local.YELP_API_KEY;
-
-// const http = axios.create({
-//     baseURL: "https://api.yelp.com/v3/businesses/search?"
-// });
-
+// Use the same base URL as the rest of the services so requests
+// are always directed to the backend API rather than the dev server.
+const http = axios.create({
+    baseURL: process.env.VUE_APP_REMOTE_API
+});
 
 export default {
     GetBusinessByNameAndZip(yelpinput) {
-        //let nameandzip = {yelpinput};
-        return axios.post('/YelpApi/', yelpinput);
+        return http.post('/YelpApi/', yelpinput);
     }
 }


### PR DESCRIPTION
## Summary
- ensure YelpService posts to backend base URL instead of dev server
- fix navigation computed property to return authentication state
- catch Yelp search errors for better feedback
- avoid undefined weather widget until data loads

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b1ecd9888333b2b90fbda5f3c892